### PR TITLE
Sync index.md with README.md in thinreports/thinreports

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,27 @@
+name: Synchronize index.md with README.md in thinreports/thinreports
+
+on:
+#  schedule:
+#    - cron: '0 */1 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update
+      run: node .github/workflows/update-index.js
+
+    - run: cat index.md
+
+    - name: Deploy if changed
+      run: |
+        if ! git diff --exit-code --quiet index.md
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Sync index.md" index.md
+          git push
+        fi

--- a/.github/workflows/update-index.js
+++ b/.github/workflows/update-index.js
@@ -1,0 +1,33 @@
+const { readFileSync, writeFileSync } = require('fs');
+const https = require('https');
+
+const README_URL = 'https://raw.githubusercontent.com/thinreports/thinreports/main/README.md';
+const INDEX_PATH = 'index.md';
+
+async function getReadme() {
+  return new Promise((resolve, reject) => {
+    https.get(README_URL, (res) => {
+      if (res.statusCode === 200) {
+        let data = '';
+        res.on('data', chunk => data += chunk);
+        res.on('end', () => resolve(data));
+      } else {
+        reject(new Error(res.statusMessage));
+      }
+    }).on('error', e => reject(e));
+  });
+}
+
+function buildIndexWith(readme) {
+  const index = readFileSync(INDEX_PATH, { encoding: 'utf-8' });
+  const header = index.match(/^\-\-\-[\s\S]+\-\-\-/m)[0];
+
+  return [header, readme].join("\n\n");
+}
+
+(async () => {
+  const readme = await getReadme();
+  const newIndex = buildIndexWith(readme);
+
+  writeFileSync(INDEX_PATH, newIndex);
+})();


### PR DESCRIPTION
## 目的

`index.md` を thinreports/thinreports の [READMD.md](https://github.com/thinreports/thinreports/blob/main/README.md) と同期するようにします。

## 方針

このリポジトリの GitHub Actions で以下を定義します。

- 1時間ごとに実行する
- thinreports/thinreports の README.md を取得し、index.md を構築
- 結果 index.md に変更点があれば push する

## その他の選択肢

その他にもいくつかの選択肢がありますが、それぞれ以下の理由で却下しました。

1. thinreports/thinreports の GitHub Actions として、README.md の更新でトリガーするワークフローを定義する。そのワークフローで、index.md を構築し、thinreports/thinreports.github.io に push する
   - -> 人に依存しない方法としては、Deploy Keys を使う方法が良いが、ワークフローの実装が割と複雑
2. 同様に thinreports/thinreports の GitHub Actions として README.md の更新でトリガーするワークフローを定義する。ただし、そのワークフローは、thinreports/thinreports.github.io に対して「READMD.md を更新した」というイベントを dispatch するだけにする。thinreports.github.io では、その「README.mdを更新した」というイベントで発火するワークフローを定義し、README.md を取得して構築、push する
   - -> 責務が分離されていて、かつリアルタイムに同期できるが、PTA (Personal Access Token) が必要。人に紐づくことになってしまうことはできるだけ避けたい

人(PTA)に紐づくことは避けたいというのが前提にあり、かつシンプルさも考慮してこの方法を採用しました。。また、同期はリアルタイムである必要もありません。

## 動作テスト

手元で `node .github/workflows/update-index.js` を実行して確認しました。

## この後の対応

このワークフローは、master にマージしないと動作確認できません。一度マージして実際に試しつつ調整します。

